### PR TITLE
Dummy out the unsupported constexpr and noexcept keywords on Visual Studio < 2015

### DIFF
--- a/vdf_parser.hpp
+++ b/vdf_parser.hpp
@@ -39,6 +39,12 @@
 // internal
 #include <stack>
 
+// Dummy out the unsupported constexpr and noexcept keywords on Visual Studio < 2015
+#if (_MSC_VER < 1900)
+#define constexpr
+#define noexcept
+#endif
+
 namespace tyti
 {
     namespace vdf
@@ -343,6 +349,11 @@ namespace tyti
 } // end namespace tyti
 #ifndef TYTI_NO_L_UNDEF
 #undef TYTI_L
+#endif
+
+#if (_MSC_VER < 1900)
+#undef constexpr
+#undef noexcept
 #endif
 
 #endif //__TYTI_STEAM_VDF_PARSER_H__


### PR DESCRIPTION
While you previously removed support for everything below `v140` from the AppVeyor configuration in f8796df8b264c0f9c44cc94d39ff98e516efcee6, this could be a good compromise for projects that are stuck on earlier Visual Studio versions for whatever reason, as the rest of the library compiles just fine.