### PR TITLE
add cmake install and disables all testing by default

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVALVEFILEVDF_ENABLE_TESTING=ON -DVALVEFILEVDF_ENABLE_FUZZING=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-build/
 .vs/
 .vscode/
+install/
+build/
 out/
+Testing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,75 @@
-cmake_minimum_required (VERSION 3.6)
-project (vdf-Parser)
+cmake_minimum_required (VERSION 3.23)
+
+project(
+  ValveFileVDF
+  VERSION 1.0.0
+  DESCRIPTION "parses valve's vdf file format"
+  HOMEPAGE_URL "https://github.com/TinyTinni/ValveFileVDF"
+  LANGUAGES CXX C)
+
+option(VALVEFILEVDF_ENABLE_TESTING OFF)
+option(VALVEFILEVDF_ENABLE_FUZZING OFF)
+
+if (VALVEFILEVDF_ENABLE_FUZZING)
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" AND NOT APPLE)
+	    set(VALVEFILEVDF_ENABLE_FUZZING ON)
+    else()
+    set(VALVEFILEVDF_ENABLE_FUZZING OFF)
+        message("Fuzzing not supported. Fuzzing gets disabled.")
+    endif()
+endif()
 
 add_library(ValveFileVDF INTERFACE)
 add_library(ValveFileVDF::ValveFileVDF ALIAS ValveFileVDF)
-target_include_directories(ValveFileVDF INTERFACE "include")
+target_sources(ValveFileVDF
+    PUBLIC FILE_SET HEADERS
+    BASE_DIRS "include"
+    FILES
+    "include/vdf_parser.hpp"
+    )
 
+#############################
+## Install
+
+set_target_properties(ValveFileVDF PROPERTIES PUBLIC_HEADER "include/vdf_parser.hpp")
+
+include(GNUInstallDirs)
+install(TARGETS ValveFileVDF
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+include(CMakePackageConfigHelpers)
+
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION cmake
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION cmake
+)
+
+
+###################################
+# Tests
 include(CTest)
-add_subdirectory(./tests)
-
-## add fuzzing, if supported
-
-set(ENABLE_FUZZING OFF)
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" AND NOT APPLE)
-	set(ENABLE_FUZZING ON)
+if (${VALVEFILEVDF_ENABLE_TESTING})
+    add_subdirectory(./tests)
 endif()
 
-if (${ENABLE_FUZZING})
+
+if (${VALVEFILEVDF_ENABLE_FUZZING})
     add_subdirectory(fuzzing)
 endif()

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+check_required_components(@PROJECT_NAME@)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,38 +1,3 @@
-set (CMAKE_CXX_STANDARD 17)
-
-##find_package(Catch2 QUIET)
-##if (NOT TARGET Catch2::Catch)
-##    include(ExternalProject)
-##    find_package(Git REQUIRED)
-##	
-##	set(BRANCH "master")
-##	if (MSVC_VERSION LESS 1900)
-##		set(BRANCH "Catch1.x") #catch2 needs C++11
-##	endif()
-##    
-##    ExternalProject_Add(
-##        catch
-##        PREFIX ${CMAKE_BINARY_DIR}/catch
-##        GIT_REPOSITORY https://github.com/philsquared/Catch.git
-##		GIT_TAG ${BRANCH}
-##        TIMEOUT 10
-##        UPDATE_COMMAND ${GIT_EXECUTABLE} pull
-##        CONFIGURE_COMMAND ""
-##        BUILD_COMMAND ""
-##        INSTALL_COMMAND ""
-##        LOG_DOWNLOAD ON
-##    )
-##    ExternalProject_Get_Property(catch source_dir)
-##    
-##    add_library(Catch INTERFACE)
-##    set(INCLUDE_POSTFIX "catch2/")
-##    if (MSVC_VERSION LESS 1900)
-##        set(INCLUDE_POSTFIX "")
-##    endif()
-##    target_include_directories(Catch INTERFACE "${source_dir}/single_include/${INCLUDE_POSTFIX}")
-##    add_dependencies(Catch catch)
-##    add_library(Catch2::Catch ALIAS Catch)
-##endif()
 
 set(SRCS
  "main.cpp"
@@ -45,6 +10,7 @@ set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT t
 set_property(TARGET tests PROPERTY COMPILE_WARNING_AS_ERROR ON)
 add_definitions("-DSOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"" "-DCATCH_AMALGAMATED_CUSTOM_MAIN")
 target_compile_definitions(tests PRIVATE "-D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS" "-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS")
+target_compile_features(tests PUBLIC cxx_std_17)
 target_link_libraries(tests PRIVATE ValveFileVDF)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")


### PR DESCRIPTION
Adds cmake install procedure.

This PR also adds versioning and file_sets. Therefore, cmake min version is increased to 3.23.

It also disables all testing by default so that the project can be included in any subproject.