### PR TITLE
Only include CTest if testing or fuzzing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,10 @@ install(FILES
 
 ###################################
 # Tests
-include(CTest)
+if (${VALVEFILEVDF_ENABLE_TESTING} OR ${VALVEFILEVDF_ENABLE_FUZZING})
+    include(CTest)
+endif()
+
 if (${VALVEFILEVDF_ENABLE_TESTING})
     add_subdirectory(./tests)
 endif()


### PR DESCRIPTION
When CTest is included, it adds a bunch of test-related targets that appear as projects in the MSVC solution (when using MSVC), e.g. Continuous, Experimental, Nightly, NightlyMemoryCheck.

A codebase that's just trying to use ValveFileVDF as a header-only library through CMake (e.g. using FetchContent) doesn't need these targets and they just clutter up the solution's list of projects, so only include CTest if testing or fuzzing is enabled.