### PR TITLE
Removes c++17 deprecation warnings

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(tests ${SRCS})
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tests) #requires cmake 3.6
 set_property(TARGET tests PROPERTY COMPILE_WARNING_AS_ERROR ON)
 add_definitions("-DSOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"" "-DCATCH_AMALGAMATED_CUSTOM_MAIN")
-target_compile_definitions(tests PRIVATE "-D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS" "-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS")
 target_compile_features(tests PUBLIC cxx_std_17)
 target_link_libraries(tests PRIVATE ValveFileVDF)
 


### PR DESCRIPTION
Those helper functions will be removed with C++26 and require to disable C++17 warning, which is inconvenient. 