### PR TITLE
feat: proptests via rapidcheck

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       env:
-        RC_PARAMS: "max_success=100000"
+        RC_PARAMS: "max_success=10000"
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure -C ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -39,6 +39,8 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
+      env:
+        RC_PARAMS: "max_success=10000"
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure -C ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       env:
-        RC_PARAMS: "max_success=10000"
+        RC_PARAMS: "max_success=100000"
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure -C ${{env.BUILD_TYPE}}

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,8 @@ This header-only file provides a parser and writer to load and save the given da
 
 ## Test Requirements
 - C++17 (uses [doctest](https://github.com/doctest/doctest))
+- property tests require C++20 (they use [rapidcheck](https://github.com/emil-e/rapidcheck))
+- fuzzing requires clang or MSVC
  
 ## How-To Use
 First, you have to include the main file `vdf-Parser.h`.

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     target_link_libraries(tests PUBLIC -fsanitize=address,undefined)
 endif()
 
-if (BUILD_TESTING)
-    add_test(NAME vdf_tests COMMAND tests)
-endif()
+
+add_test(NAME vdf_tests COMMAND tests)
+
+add_subdirectory(proptests)
+

--- a/tests/proptests/CMakeLists.txt
+++ b/tests/proptests/CMakeLists.txt
@@ -29,5 +29,5 @@ endif()
 
 
 add_test(NAME vdf_rapidcheck_tests COMMAND rapidcheck_tests)
-set_tests_properties(vdf_rapidcheck_tests PROPERTIES ENVIRONMENT "RC_PARAMS=max_success=1000")
+set_tests_properties(vdf_rapidcheck_tests PROPERTIES ENVIRONMENT "RC_PARAMS=max_success=10000")
 

--- a/tests/proptests/CMakeLists.txt
+++ b/tests/proptests/CMakeLists.txt
@@ -29,5 +29,4 @@ endif()
 
 
 add_test(NAME vdf_rapidcheck_tests COMMAND rapidcheck_tests)
-set_tests_properties(vdf_rapidcheck_tests PROPERTIES ENVIRONMENT "RC_PARAMS=max_success=10000")
 

--- a/tests/proptests/CMakeLists.txt
+++ b/tests/proptests/CMakeLists.txt
@@ -4,7 +4,7 @@ CPMAddPackage(NAME rapidcheck
     GITHUB_REPOSITORY "emil-e/rapidcheck"
     GIT_TAG "ff6af6fc683159deb51c543b065eba14dfcf329b"
     OPTIONS
-    "RC_ENABLE_DOCTEST ON"
+    "RC_ENABLE_DOCTEST OFF"
     "CATCH_BUILD_TESTING OFF"
     "CATCH_INSTALL_DOCS OFF"
 )

--- a/tests/proptests/CMakeLists.txt
+++ b/tests/proptests/CMakeLists.txt
@@ -1,0 +1,33 @@
+include (../../cmake/get_cpm.cmake)
+
+CPMAddPackage(NAME rapidcheck
+    GITHUB_REPOSITORY "emil-e/rapidcheck"
+    GIT_TAG "ff6af6fc683159deb51c543b065eba14dfcf329b"
+    OPTIONS
+    "RC_ENABLE_DOCTEST ON"
+    "CATCH_BUILD_TESTING OFF"
+    "CATCH_INSTALL_DOCS OFF"
+)
+
+get_property(rapidcheck_include_dirs TARGET rapidcheck PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+set_property(TARGET rapidcheck PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${rapidcheck_include_dirs}")
+
+add_executable(rapidcheck_tests "main_rapidcheck.cpp")
+set_property(TARGET tests PROPERTY COMPILE_WARNING_AS_ERROR ON)
+target_compile_features(rapidcheck_tests PUBLIC cxx_std_20)
+target_link_libraries(rapidcheck_tests PRIVATE ValveFileVDF rapidcheck)
+
+target_compile_options(rapidcheck_tests PRIVATE
+     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+          -Wall -Wextra -Wconversion -pedantic-errors -Wsign-conversion>
+     $<$<CXX_COMPILER_ID:MSVC>:
+          /W4>)
+
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_link_libraries(rapidcheck_tests PUBLIC -fsanitize=address,undefined)
+endif()
+
+
+add_test(NAME vdf_rapidcheck_tests COMMAND rapidcheck_tests)
+set_tests_properties(vdf_rapidcheck_tests PROPERTIES ENVIRONMENT "RC_PARAMS=max_success=1000")
+

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -86,13 +86,16 @@ template <> struct Arbitrary<tyti::vdf::object>
 
 int main()
 {
+    ////////////////////////////////////////////////////////////////
+    // object parsing tests
+
     using namespace tyti;
     rc::check("serializing and then parsing just the name with default options "
               "should return the original name",
-              [](std::string n)
+              []()
               {
                   vdf::object obj;
-                  obj.name = n;
+                  obj.name = *rc::gen::string<std::string>();
 
                   std::stringstream sstr;
                   vdf::write(sstr, obj);
@@ -129,6 +132,9 @@ int main()
                   auto to_test = tyti::vdf::read(sstr);
                   RC_ASSERT(in == to_test);
               });
+
+    ////////////////////////////////////////////////////////////////
+    // comments parsing tests
 
     rc::check("single line comment should not cause any errors",
               []()

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -22,9 +22,20 @@ bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
         auto itr = lhs.childs.find(k);
         if (itr == lhs.childs.end())
             return false;
+
+#ifdef _MSC_VER
+// suppress warning about recursive call of operator==. This is here
+// by intention
+#pragma warning(disable : 5232)
+#endif
         if (itr->second != v)
+        {
             if (itr->second == nullptr || v == nullptr || *(itr->second) != *v)
                 return false;
+        }
+#ifdef _MSC_VER
+#pragma warning(default : 5232)
+#endif
     }
 
     return true;

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -87,8 +87,8 @@ template <> struct Arbitrary<tyti::vdf::object>
 int main()
 {
     using namespace tyti;
-    rc::check("serializing and then parsing with default options should yield "
-              "original name",
+    rc::check("serializing and then parsing just the name with default options "
+              "should return the original name",
               [](std::string n)
               {
                   vdf::object obj;

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -110,10 +110,32 @@ int main()
                   RC_ASSERT(in == to_test);
               });
 
-    rc::check("single line comment should not cause any errors",
-              [](const std::string &comment)
+    rc::check("check if the childs are also written and parsed correctly",
+              [](vdf::object in)
               {
-                  RC_PRE(comment.find("\n") == comment.npos);
+                  // todo this just tests childs with depth 1
+                  using child_vec = std::vector<std::shared_ptr<vdf::object>>;
+                  child_vec childs = *rc::gen::container<child_vec>(
+                      rc::gen::makeShared<vdf::object>(
+                          rc::gen::arbitrary<vdf::object>()));
+
+                  for (const auto &c : childs)
+                  {
+                      in.childs[c->name] = c;
+                  }
+
+                  std::stringstream sstr;
+                  vdf::write(sstr, in);
+                  auto to_test = tyti::vdf::read(sstr);
+                  RC_ASSERT(in == to_test);
+              });
+
+    rc::check("single line comment should not cause any errors",
+              []()
+              {
+                  auto comment = *rc::gen::suchThat(
+                      rc::gen::string<std::string>(), [](const std::string &str)
+                      { return str.find("\n") == str.npos; });
 
                   std::stringstream input;
                   input << "\"test\""
@@ -128,9 +150,11 @@ int main()
               });
 
     rc::check("multi line comment should not cause any errors",
-              [](const std::string &comment)
+              []()
               {
-                  RC_PRE(comment.find("*/") == comment.npos);
+                  auto comment = *rc::gen::suchThat(
+                      rc::gen::string<std::string>(), [](const std::string &str)
+                      { return str.find("*/") == str.npos; });
 
                   std::stringstream input;
                   input << "\"test\""

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -1,0 +1,137 @@
+#include <algorithm>
+#include <string>
+#include <vdf_parser.hpp>
+
+namespace rc::detail
+{
+bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
+{
+    if (rhs.name != lhs.name)
+        return false;
+    return true;
+    for (const auto &[k, v] : rhs.attribs)
+    {
+        auto itr = lhs.attribs.find(k);
+        if (itr == lhs.attribs.end())
+            return false;
+        if (itr->second != v)
+            return false;
+    }
+    for (const auto &[k, v] : rhs.childs)
+    {
+        auto itr = lhs.childs.find(k);
+        if (itr == lhs.childs.end())
+            return false;
+        if (itr->second != v)
+            if (itr->second == nullptr || v == nullptr || *(itr->second) != *v)
+                return false;
+    }
+
+    return true;
+}
+
+void showValue(tyti::vdf::object obj, std::ostream &os)
+{
+    os << "name: " << obj.name << "\n";
+    os << "attribs (size:" << obj.attribs.size() << "): \n";
+    for (const auto &[k, v] : obj.attribs)
+        os << k << "\t" << v << "\n";
+    os << "childs: (size:" << obj.childs.size() << "): \n";
+    for (const auto &[k, v] : obj.childs)
+    {
+        os << k << "\t";
+        if (v)
+            showValue(*v, os);
+        else
+            os << "nullptr!";
+        os << "\n";
+    }
+}
+void showValue(const std::tuple<tyti::vdf::object, tyti::vdf::object> &objs,
+               std::ostream &os)
+{
+    os << "[LHS]: \n";
+    showValue(std::get<0>(objs), os);
+    os << "[RHS]: \n";
+    showValue(std::get<1>(objs), os);
+}
+} // namespace rc::detail
+
+#include <rapidcheck.h>
+
+namespace rc
+{
+
+template <> struct Arbitrary<tyti::vdf::object>
+{
+    static Gen<tyti::vdf::object> arbitrary()
+    {
+        using tyti::vdf::object;
+        return gen::build<object>(gen::set(&object::name),
+                                  gen::set(&object::attribs));
+    }
+};
+} // namespace rc
+
+int main()
+{
+    using namespace tyti;
+    rc::check("serializing and then parsing with default options should yield "
+              "original name",
+              [](std::string n)
+              {
+                  vdf::object obj;
+                  obj.name = n;
+
+                  std::stringstream sstr;
+                  vdf::write(sstr, obj);
+
+                  auto to_test = vdf::read(sstr);
+                  RC_ASSERT(obj.name == to_test.name);
+              });
+
+    rc::check("check if the attributes are also written and parsed correctly",
+              [](const vdf::object &in)
+              {
+                  std::stringstream sstr;
+                  vdf::write(sstr, in);
+                  auto to_test = tyti::vdf::read(sstr);
+                  RC_ASSERT(in == to_test);
+              });
+
+    rc::check("single line comment should not cause any errors",
+              [](const std::string &comment)
+              {
+                  RC_PRE(comment.find("\n") == comment.npos);
+
+                  std::stringstream input;
+                  input << "\"test\""
+                        << "{"
+                        << "//" << comment << "\n"
+                        << "\"key\" \"value\"\n"
+                        << "}";
+                  auto to_test = vdf::read(input);
+                  RC_ASSERT("test" == to_test.name);
+                  RC_ASSERT(1 == to_test.attribs.size());
+                  RC_ASSERT("value" == to_test.attribs["key"]);
+              });
+
+    rc::check("multi line comment should not cause any errors",
+              [](const std::string &comment)
+              {
+                  RC_PRE(comment.find("*/") == comment.npos);
+
+                  std::stringstream input;
+                  input << "\"test\""
+                        << "{"
+                        << "/*" << comment << "*/"
+                        << "\"key\" \"value\"\n"
+                        << "}";
+                  auto to_test = vdf::read(input);
+                  RC_ASSERT("test" == to_test.name);
+                  RC_ASSERT(1 == to_test.attribs.size());
+                  RC_ASSERT("value" == to_test.attribs["key"]);
+              });
+
+    return 0;
+}

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -104,6 +104,20 @@ int main()
                   RC_ASSERT(obj.name == to_test.name);
               });
 
+    rc::check("serializing and then parsing just the name with default options "
+              "should return the original name - wchar_t",
+              []()
+              {
+                  vdf::wobject obj;
+                  obj.name = *rc::gen::string<std::wstring>();
+
+                  std::wstringstream sstr;
+                  vdf::write(sstr, obj);
+
+                  auto to_test = vdf::read(sstr);
+                  RC_ASSERT(obj.name == to_test.name);
+              });
+
     rc::check("check if the attributes are also written and parsed correctly",
               [](const vdf::object &in)
               {

--- a/tests/testdata/DST_Manifest.acf
+++ b/tests/testdata/DST_Manifest.acf
@@ -28,6 +28,7 @@
     "escape_quote_backslash" "quote_with_other_escapes\\\"\\"
     "tab_escape" "new\ttab"
     "new_line_escape" "new\nline"
+    "quad_escape" "\\\\"
 
 	"conditional" "macos" [$OSX]
 	"conditional" "not osx" [!$OSX]

--- a/tests/vdf_parser_test.cpp
+++ b/tests/vdf_parser_test.cpp
@@ -207,11 +207,14 @@ TEST_CASE("issue14")
 TEST_CASE_TEMPLATE("Write escaped", charT, char, wchar_t)
 {
     std::vector<std::basic_string<charT>> data = {
-        TYTI_L(charT, "\""), TYTI_L(charT, "\\"), TYTI_L(charT, "\\\\"),
-        TYTI_L(charT, "\\\\\\"), TYTI_L(charT, "\"\\\"")};
+        TYTI_L(charT, "\""),        TYTI_L(charT, "\\"),
+        TYTI_L(charT, "\\\\"),      TYTI_L(charT, "\\\\\\"),
+        TYTI_L(charT, "\"\\\""),    TYTI_L(charT, "\\\""),
+        TYTI_L(charT, "\\\\\"\\\\")};
     for (const auto &datapoint : data)
     {
         CAPTURE(datapoint);
+
         vdf::basic_object<charT> obj;
         obj.name = datapoint;
 

--- a/tests/vdf_parser_test.cpp
+++ b/tests/vdf_parser_test.cpp
@@ -207,10 +207,10 @@ TEST_CASE("issue14")
 TEST_CASE_TEMPLATE("Write escaped", charT, char, wchar_t)
 {
     std::vector<std::basic_string<charT>> data = {
-        TYTI_L(charT, "\""),        TYTI_L(charT, "\\"),
-        TYTI_L(charT, "\\\\"),      TYTI_L(charT, "\\\\\\"),
-        TYTI_L(charT, "\"\\\""),    TYTI_L(charT, "\\\""),
-        TYTI_L(charT, "\\\\\"\\\\")};
+        TYTI_L(charT, "\""),     TYTI_L(charT, "\\"),
+        TYTI_L(charT, "\\\\"),   TYTI_L(charT, "\"\""),
+        TYTI_L(charT, "\\\\\\"), TYTI_L(charT, "\"\\\""),
+        TYTI_L(charT, "\\\""),   TYTI_L(charT, "\\\\\"\\\\")};
     for (const auto &datapoint : data)
     {
         CAPTURE(datapoint);

--- a/tests/vdf_parser_test.cpp
+++ b/tests/vdf_parser_test.cpp
@@ -15,7 +15,7 @@ template <typename charT>
 void check_DST_AST(const vdf::basic_object<charT> &obj)
 {
     CHECK(obj.name == T_L("AppState"));
-    REQUIRE(obj.attribs.size() == 24);
+    REQUIRE(obj.attribs.size() == 25);
     REQUIRE(obj.childs.size() == 4);
 
     CHECK(obj.attribs.at(T_L("appid")) == T_L("343050"));
@@ -33,6 +33,7 @@ void check_DST_AST(const vdf::basic_object<charT> &obj)
           T_L("quote_with_other_escapes\\\"\\"));
     CHECK(obj.attribs.at(T_L("tab_escape")) == T_L("new\\ttab"));
     CHECK(obj.attribs.at(T_L("new_line_escape")) == T_L("new\\nline"));
+    CHECK(obj.attribs.at(T_L("quad_escape")) == T_L("\\\\"));
 #endif
 
     CHECK(obj.childs.at(T_L("UserConfig"))->name == T_L("UserConfig"));
@@ -51,7 +52,7 @@ template <typename charT>
 void check_DST_AST_multikey(const vdf::basic_multikey_object<charT> &obj)
 {
     CHECK(obj.name == T_L("AppState"));
-    REQUIRE(obj.attribs.size() == 25);
+    REQUIRE(obj.attribs.size() == 26);
     REQUIRE(obj.childs.size() == 4);
 
     CHECK(obj.attribs.find(T_L("appid"))->second == T_L("343050"));
@@ -200,6 +201,30 @@ TEST_CASE("issue14")
 }
 
 /////////////////////////////////////////////////////////////
+// write test
+/////////////////////////////////////////////////////////////
+
+TEST_CASE_TEMPLATE("Write escaped", charT, char, wchar_t)
+{
+    std::vector<std::basic_string<charT>> data = {
+        TYTI_L(charT, "\""), TYTI_L(charT, "\\"), TYTI_L(charT, "\\\\"),
+        TYTI_L(charT, "\\\\\\"), TYTI_L(charT, "\"\\\"")};
+    for (const auto &datapoint : data)
+    {
+        CAPTURE(datapoint);
+        vdf::basic_object<charT> obj;
+        obj.name = datapoint;
+
+        std::basic_stringstream<charT> output;
+        vdf::write(output, obj);
+        auto test_obj = vdf::read(output);
+
+        CAPTURE(output.str());
+        CHECK(test_obj.name == obj.name);
+    }
+}
+
+/////////////////////////////////////////////////////////////
 // readme test
 /////////////////////////////////////////////////////////////
 
@@ -219,7 +244,7 @@ TEST_CASE("counter test")
 
     std::ifstream file("DST_Manifest.acf");
     counter num = tyti::vdf::read<counter>(file);
-    CHECK(num.num_attributes == 29);
+    CHECK(num.num_attributes == 30);
 }
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adds proptests via rapidcheck.

It also fixes a bug with mulktiple occurances of the escaped character "\\\\" in succession.

Another feature is that the writer now escapes the characters.
Beware that this breaks backward compatibility.