### PR TITLE
feat: Write option for non escaped write

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -145,6 +145,11 @@ struct Options
     bool ignore_includes; //default false
 };
 
+struct WriteOptions
+{
+    bool escape_symbols; //default true
+};
+
 ```
 
 ## Reference
@@ -267,7 +272,7 @@ struct Options
   /// writes given obj into out in vdf style 
   /// Output is prettyfied, using tabs
   template<typename oStreamT, typename T>
-  void write(oStreamT& out, const T& obj);
+  void write(oStreamT& out, const T& obj, const WriteOptions& opts);
   
 ```
 

--- a/fuzzing/main.cpp
+++ b/fuzzing/main.cpp
@@ -1,13 +1,19 @@
 #include <cstdint>
 #include <string_view>
 
-#include <vdf_parser.hpp>
 #include <iostream>
+#include <vdf_parser.hpp>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    std::string_view test_corpus{reinterpret_cast<const char *>(data), size};
+    if (size == 0)
+        return 0;
+    std::string_view test_corpus{reinterpret_cast<const char *>(data + 1),
+                                 size};
+    tyti::vdf::Options opts;
+    opts.strip_escape_symbols = data[0] != 0;
     bool ok;
-    auto result = tyti::vdf::read(test_corpus.begin(), test_corpus.end(), &ok);
+    auto result =
+        tyti::vdf::read(test_corpus.begin(), test_corpus.end(), &ok, opts);
     return 0;
 }

--- a/fuzzing/main.cpp
+++ b/fuzzing/main.cpp
@@ -6,12 +6,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    if (size == 0)
-        return 0;
-    std::string_view test_corpus{reinterpret_cast<const char *>(data + 1),
-                                 size};
+    std::string_view test_corpus{reinterpret_cast<const char *>(data), size};
     tyti::vdf::Options opts;
-    opts.strip_escape_symbols = data[0] != 0;
     bool ok;
     auto result =
         tyti::vdf::read(test_corpus.begin(), test_corpus.end(), &ok, opts);

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -118,6 +118,28 @@ int main()
                   RC_ASSERT(obj.name == to_test.name);
               });
 
+    rc::check("serializing and then parsing just the name with default options "
+              "should return the original name - not escaped",
+              []()
+              {
+                  vdf::object obj;
+                  obj.name = *rc::gen::suchThat(
+                      rc::gen::string<std::string>(), [](const std::string &str)
+                      { return str.find("\"") == str.npos; });
+
+                  vdf::WriteOptions writeOpts;
+                  writeOpts.escape_symbols = false;
+
+                  vdf::Options readOpts;
+                  readOpts.strip_escape_symbols = false;
+
+                  std::stringstream sstr;
+                  vdf::write(sstr, obj, writeOpts);
+
+                  auto to_test = vdf::read(sstr, readOpts);
+                  RC_ASSERT(obj.name == to_test.name);
+              });
+
     rc::check("check if the attributes are also written and parsed correctly",
               [](const vdf::object &in)
               {

--- a/tests/vdf_parser_test.cpp
+++ b/tests/vdf_parser_test.cpp
@@ -227,6 +227,36 @@ TEST_CASE_TEMPLATE("Write escaped", charT, char, wchar_t)
     }
 }
 
+TEST_CASE_TEMPLATE("write not-escaped", charT, char, wchar_t)
+{
+
+    vdf::WriteOptions writeOpts;
+    writeOpts.escape_symbols = false;
+
+    vdf::Options readOpts;
+    readOpts.strip_escape_symbols = false;
+    std::vector<std::basic_string<charT>> data = {
+        TYTI_L(charT, "\\"),
+        TYTI_L(charT, "\\\\"),
+        TYTI_L(charT, "\\\\\\"),
+
+    };
+    for (const auto &datapoint : data)
+    {
+        CAPTURE(datapoint);
+
+        vdf::basic_object<charT> obj;
+        obj.name = datapoint;
+
+        std::basic_stringstream<charT> output;
+        vdf::write(output, obj, writeOpts);
+        auto test_obj = vdf::read(output, readOpts);
+
+        CAPTURE(output.str());
+        CHECK(test_obj.name == obj.name);
+    }
+}
+
 /////////////////////////////////////////////////////////////
 // readme test
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
also fixes a bug when reading with not escaped symbols containing \ at the end.