### PR TITLE
refactor: multikey_object proptests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       env:
-        RC_PARAMS: "max_success=10000"
+        RC_PARAMS: "max_success=1000"
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure -C ${{env.BUILD_TYPE}}

--- a/tests/proptests/CMakeLists.txt
+++ b/tests/proptests/CMakeLists.txt
@@ -12,7 +12,7 @@ CPMAddPackage(NAME rapidcheck
 get_property(rapidcheck_include_dirs TARGET rapidcheck PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 set_property(TARGET rapidcheck PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${rapidcheck_include_dirs}")
 
-add_executable(rapidcheck_tests "main_rapidcheck.cpp")
+add_executable(rapidcheck_tests "main_rapidcheck.cpp;generators/vdf_object_generator.cpp;generators/vdf_multiobject_generator.cpp")
 target_compile_features(rapidcheck_tests PUBLIC cxx_std_20)
 target_link_libraries(rapidcheck_tests PRIVATE ValveFileVDF rapidcheck)
 

--- a/tests/proptests/CMakeLists.txt
+++ b/tests/proptests/CMakeLists.txt
@@ -20,7 +20,7 @@ target_compile_options(rapidcheck_tests PRIVATE
      $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
           -Wall -Wextra -Wconversion -pedantic-errors -Wsign-conversion>
      $<$<CXX_COMPILER_ID:MSVC>:
-          /W4>)
+          /W4 /bigobj>)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     target_link_libraries(rapidcheck_tests PUBLIC -fsanitize=address,undefined)

--- a/tests/proptests/generators/string_generator.hpp
+++ b/tests/proptests/generators/string_generator.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <rapidcheck.h>
+#include <string>
+
+inline bool containsSurrogate(const std::wstring &str)
+{
+    return str.find(wchar_t(-1)) != str.npos;
+}
+
+////////////////////////////////////////////////////////////////
+template <typename charT>
+rc::Gen<std::basic_string<charT>> genValidNameString();
+
+template <> inline rc::Gen<std::basic_string<char>> genValidNameString<char>()
+{
+    return rc::gen::string<std::string>();
+}
+
+template <>
+inline rc::Gen<std::basic_string<wchar_t>> genValidNameString<wchar_t>()
+{
+    return rc::gen::suchThat(rc::gen::string<std::wstring>(),
+                             [](const auto &str)
+                             { return !containsSurrogate(str); });
+}
+
+////////////////////////////////////////////////////////////////
+template <typename charT>
+rc::Gen<std::basic_string<charT>> genValidUnescapedNameString();
+
+template <> inline rc::Gen<std::string> genValidUnescapedNameString<char>()
+{
+    return rc::gen::suchThat(rc::gen::string<std::string>(),
+                             [](const std::string &str)
+                             { return str.find("\"") == str.npos; });
+}
+
+template <> inline rc::Gen<std::wstring> genValidUnescapedNameString<wchar_t>()
+{
+    return rc::gen::suchThat(
+        rc::gen::string<std::wstring>(), [](const std::wstring &str)
+        { return str.find(L"\"") == str.npos && !containsSurrogate(str); });
+}

--- a/tests/proptests/generators/string_generator.hpp
+++ b/tests/proptests/generators/string_generator.hpp
@@ -30,14 +30,13 @@ rc::Gen<std::basic_string<charT>> gen_unescaped_name_string();
 
 template <> inline rc::Gen<std::string> gen_unescaped_name_string<char>()
 {
-    return rc::gen::suchThat(rc::gen::string<std::string>(),
-                             [](const std::string &str)
+    return rc::gen::suchThat(gen_name_string<char>(), [](const std::string &str)
                              { return str.find("\"") == str.npos; });
 }
 
 template <> inline rc::Gen<std::wstring> gen_unescaped_name_string<wchar_t>()
 {
-    return rc::gen::suchThat(
-        rc::gen::string<std::wstring>(), [](const std::wstring &str)
-        { return str.find(L"\"") == str.npos && !contains_surrogate(str); });
+    return rc::gen::suchThat(gen_name_string<wchar_t>(),
+                             [](const std::wstring &str)
+                             { return str.find(L"\"") == str.npos; });
 }

--- a/tests/proptests/generators/string_generator.hpp
+++ b/tests/proptests/generators/string_generator.hpp
@@ -3,42 +3,41 @@
 #include <rapidcheck.h>
 #include <string>
 
-inline bool containsSurrogate(const std::wstring &str)
+inline bool contains_surrogate(const std::wstring &str)
 {
     return str.find(wchar_t(-1)) != str.npos;
 }
 
 ////////////////////////////////////////////////////////////////
-template <typename charT>
-rc::Gen<std::basic_string<charT>> genValidNameString();
+template <typename charT> rc::Gen<std::basic_string<charT>> gen_name_string();
 
-template <> inline rc::Gen<std::basic_string<char>> genValidNameString<char>()
+template <> inline rc::Gen<std::basic_string<char>> gen_name_string<char>()
 {
     return rc::gen::string<std::string>();
 }
 
 template <>
-inline rc::Gen<std::basic_string<wchar_t>> genValidNameString<wchar_t>()
+inline rc::Gen<std::basic_string<wchar_t>> gen_name_string<wchar_t>()
 {
     return rc::gen::suchThat(rc::gen::string<std::wstring>(),
                              [](const auto &str)
-                             { return !containsSurrogate(str); });
+                             { return !contains_surrogate(str); });
 }
 
 ////////////////////////////////////////////////////////////////
 template <typename charT>
-rc::Gen<std::basic_string<charT>> genValidUnescapedNameString();
+rc::Gen<std::basic_string<charT>> gen_unescaped_name_string();
 
-template <> inline rc::Gen<std::string> genValidUnescapedNameString<char>()
+template <> inline rc::Gen<std::string> gen_unescaped_name_string<char>()
 {
     return rc::gen::suchThat(rc::gen::string<std::string>(),
                              [](const std::string &str)
                              { return str.find("\"") == str.npos; });
 }
 
-template <> inline rc::Gen<std::wstring> genValidUnescapedNameString<wchar_t>()
+template <> inline rc::Gen<std::wstring> gen_unescaped_name_string<wchar_t>()
 {
     return rc::gen::suchThat(
         rc::gen::string<std::wstring>(), [](const std::wstring &str)
-        { return str.find(L"\"") == str.npos && !containsSurrogate(str); });
+        { return str.find(L"\"") == str.npos && !contains_surrogate(str); });
 }

--- a/tests/proptests/generators/vdf_multiobject_generator.cpp
+++ b/tests/proptests/generators/vdf_multiobject_generator.cpp
@@ -1,0 +1,63 @@
+#include "vdf_multiobject_generator.hpp"
+
+namespace tyti::vdf
+{
+bool operator==(const tyti::vdf::multikey_object &rhs,
+                const tyti::vdf::multikey_object &lhs)
+{
+    if (rhs.name != lhs.name)
+        return false;
+    if (rhs.attribs != lhs.attribs)
+        return false;
+    for (const auto &[k, v] : rhs.childs)
+    {
+        auto [begin, end] = lhs.childs.equal_range(k);
+
+#ifdef _MSC_VER
+// suppress warning about recursive call of operator==. This is here
+// by intention
+#pragma warning(disable : 5232)
+#endif
+        while (begin != end)
+        {
+            if (begin->second == nullptr && v == nullptr)
+                return true;
+            if (*(begin->second) == *v)
+                return true;
+            ++begin;
+        }
+        return false;
+#ifdef _MSC_VER
+#pragma warning(default : 5232)
+#endif
+    }
+
+    return true;
+}
+} // namespace tyti::vdf
+
+namespace rc::detail
+{
+
+void showValue(tyti::vdf::multikey_object obj, std::ostream &os)
+{
+    os << "name: " << obj.name << "\n";
+    os << "attribs (size:" << obj.attribs.size() << "): \n";
+    for (const auto &[k, v] : obj.attribs)
+        os << k << "\t" << v << "\n";
+    os << "childs: (size:" << obj.childs.size() << "): \n";
+    for (const auto &[k, v] : obj.childs)
+    {
+        os << "'" << k << "'\t'";
+        if (v)
+            showValue(*v, os);
+        else
+            os << "nullptr!";
+
+        os << "'\n";
+    }
+
+    os << "'\n";
+}
+
+} // namespace rc::detail

--- a/tests/proptests/generators/vdf_multiobject_generator.cpp
+++ b/tests/proptests/generators/vdf_multiobject_generator.cpp
@@ -1,9 +1,8 @@
 #include "vdf_multiobject_generator.hpp"
 
-namespace tyti::vdf
-{
-bool operator==(const tyti::vdf::multikey_object &rhs,
-                const tyti::vdf::multikey_object &lhs)
+template <typename charT>
+bool equal_impl(const tyti::vdf::basic_multikey_object<charT> &rhs,
+                const tyti::vdf::basic_multikey_object<charT> &lhs)
 {
     if (rhs.name != lhs.name)
         return false;
@@ -34,6 +33,20 @@ bool operator==(const tyti::vdf::multikey_object &rhs,
 
     return true;
 }
+namespace tyti::vdf
+{
+
+bool operator==(const tyti::vdf::multikey_object &rhs,
+                const tyti::vdf::multikey_object &lhs)
+{
+    return equal_impl(rhs, lhs);
+}
+bool operator==(const tyti::vdf::wmultikey_object &rhs,
+                const tyti::vdf::wmultikey_object &lhs)
+{
+    return equal_impl(rhs, lhs);
+}
+
 } // namespace tyti::vdf
 
 namespace rc::detail

--- a/tests/proptests/generators/vdf_multiobject_generator.hpp
+++ b/tests/proptests/generators/vdf_multiobject_generator.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <rapidcheck.h>
+#include <vdf_parser.hpp>
+
+namespace tyti::vdf
+{
+bool operator==(const tyti::vdf::multikey_object &rhs,
+                const tyti::vdf::multikey_object &lhs);
+} // namespace tyti::vdf
+
+namespace rc
+{
+
+template <> struct Arbitrary<tyti::vdf::multikey_object>
+{
+    static Gen<tyti::vdf::multikey_object> arbitrary()
+    {
+        using tyti::vdf::multikey_object;
+        return gen::build<multikey_object>(gen::set(&multikey_object::name),
+                                           gen::set(&multikey_object::attribs));
+    }
+};
+} // namespace rc
+
+namespace rc::detail
+{
+
+void showValue(tyti::vdf::multikey_object obj, std::ostream &os);
+
+} // namespace rc::detail

--- a/tests/proptests/generators/vdf_multiobject_generator.hpp
+++ b/tests/proptests/generators/vdf_multiobject_generator.hpp
@@ -7,18 +7,20 @@ namespace tyti::vdf
 {
 bool operator==(const tyti::vdf::multikey_object &rhs,
                 const tyti::vdf::multikey_object &lhs);
+bool operator==(const tyti::vdf::wmultikey_object &rhs,
+                const tyti::vdf::wmultikey_object &lhs);
 } // namespace tyti::vdf
 
 namespace rc
 {
 
-template <> struct Arbitrary<tyti::vdf::multikey_object>
+template <typename charT>
+struct Arbitrary<tyti::vdf::basic_multikey_object<charT>>
 {
-    static Gen<tyti::vdf::multikey_object> arbitrary()
+    static Gen<tyti::vdf::basic_multikey_object<charT>> arbitrary()
     {
-        using tyti::vdf::multikey_object;
-        return gen::build<multikey_object>(gen::set(&multikey_object::name),
-                                           gen::set(&multikey_object::attribs));
+        using obj = tyti::vdf::basic_multikey_object<charT>;
+        return gen::build<obj>(gen::set(&obj::name), gen::set(&obj::attribs));
     }
 };
 } // namespace rc

--- a/tests/proptests/generators/vdf_multiobject_generator.hpp
+++ b/tests/proptests/generators/vdf_multiobject_generator.hpp
@@ -31,13 +31,13 @@ template <> struct Arbitrary<tyti::vdf::wmultikey_object>
     {
         using obj = tyti::vdf::wmultikey_object;
         return gen::build<obj>(
-            gen::set(&obj::name, genValidNameString<wchar_t>()),
-            gen::set(&obj::attribs,
+            gen::set(&obj::name, gen_name_string<wchar_t>()),
+            gen::set(
+                &obj::attribs,
 
-                     rc::gen::container<
-                         std::unordered_multimap<std::wstring, std::wstring>>(
-                         genValidNameString<wchar_t>(),
-                         genValidNameString<wchar_t>())));
+                rc::gen::container<
+                    std::unordered_multimap<std::wstring, std::wstring>>(
+                    gen_name_string<wchar_t>(), gen_name_string<wchar_t>())));
     }
 };
 } // namespace rc

--- a/tests/proptests/generators/vdf_multiobject_generator.hpp
+++ b/tests/proptests/generators/vdf_multiobject_generator.hpp
@@ -3,6 +3,8 @@
 #include <rapidcheck.h>
 #include <vdf_parser.hpp>
 
+#include "string_generator.hpp"
+
 namespace tyti::vdf
 {
 bool operator==(const tyti::vdf::multikey_object &rhs,
@@ -14,13 +16,28 @@ bool operator==(const tyti::vdf::wmultikey_object &rhs,
 namespace rc
 {
 
-template <typename charT>
-struct Arbitrary<tyti::vdf::basic_multikey_object<charT>>
+template <> struct Arbitrary<tyti::vdf::multikey_object>
 {
-    static Gen<tyti::vdf::basic_multikey_object<charT>> arbitrary()
+    static Gen<tyti::vdf::multikey_object> arbitrary()
     {
-        using obj = tyti::vdf::basic_multikey_object<charT>;
+        using obj = tyti::vdf::multikey_object;
         return gen::build<obj>(gen::set(&obj::name), gen::set(&obj::attribs));
+    }
+};
+
+template <> struct Arbitrary<tyti::vdf::wmultikey_object>
+{
+    static Gen<tyti::vdf::wmultikey_object> arbitrary()
+    {
+        using obj = tyti::vdf::wmultikey_object;
+        return gen::build<obj>(
+            gen::set(&obj::name, genValidNameString<wchar_t>()),
+            gen::set(&obj::attribs,
+
+                     rc::gen::container<
+                         std::unordered_multimap<std::wstring, std::wstring>>(
+                         genValidNameString<wchar_t>(),
+                         genValidNameString<wchar_t>())));
     }
 };
 } // namespace rc

--- a/tests/proptests/generators/vdf_object_generator.cpp
+++ b/tests/proptests/generators/vdf_object_generator.cpp
@@ -1,8 +1,8 @@
 #include "vdf_object_generator.hpp"
 
-namespace tyti::vdf
-{
-bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
+template <typename charT>
+bool equal_impl(const tyti::vdf::basic_object<charT> &rhs,
+                const tyti::vdf::basic_object<charT> &lhs)
 {
     if (rhs.name != lhs.name)
         return false;
@@ -33,6 +33,20 @@ bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
 
     return true;
 }
+
+namespace tyti::vdf
+{
+
+bool operator==(const tyti::vdf::wobject &rhs, const tyti::vdf::wobject &lhs)
+{
+    return equal_impl(rhs, lhs);
+}
+
+bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
+{
+    return equal_impl(rhs, lhs);
+}
+
 } // namespace tyti::vdf
 
 namespace rc::details

--- a/tests/proptests/generators/vdf_object_generator.cpp
+++ b/tests/proptests/generators/vdf_object_generator.cpp
@@ -1,0 +1,66 @@
+#include "vdf_object_generator.hpp"
+
+namespace tyti::vdf
+{
+bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
+{
+    if (rhs.name != lhs.name)
+        return false;
+    if (rhs.attribs != lhs.attribs)
+        return false;
+    for (const auto &[k, v] : rhs.childs)
+    {
+        auto itr = lhs.childs.find(k);
+        if (itr == lhs.childs.end())
+        {
+            return false;
+        }
+
+#ifdef _MSC_VER
+// suppress warning about recursive call of operator==. This is here
+// by intention
+#pragma warning(disable : 5232)
+#endif
+        if (itr->second != v)
+        {
+            if (itr->second == nullptr || v == nullptr)
+                return *(itr->second) != *v;
+        }
+#ifdef _MSC_VER
+#pragma warning(default : 5232)
+#endif
+    }
+
+    return true;
+}
+} // namespace tyti::vdf
+
+namespace rc::details
+{
+void showValue(tyti::vdf::object obj, std::ostream &os)
+{
+    os << "name: " << obj.name << "\n";
+    os << "attribs (size:" << obj.attribs.size() << "): \n";
+    for (const auto &[k, v] : obj.attribs)
+        os << k << "\t" << v << "\n";
+    os << "childs: (size:" << obj.childs.size() << "): \n";
+    for (const auto &[k, v] : obj.childs)
+    {
+        os << k << "\t";
+        if (v)
+            showValue(*v, os);
+        else
+            os << "nullptr!";
+        os << "\n";
+    }
+}
+
+void showValue(const std::tuple<tyti::vdf::object, tyti::vdf::object> &objs,
+               std::ostream &os)
+{
+    os << "[LHS]: \n";
+    showValue(std::get<0>(objs), os);
+    os << "[RHS]: \n";
+    showValue(std::get<1>(objs), os);
+}
+} // namespace rc::details

--- a/tests/proptests/generators/vdf_object_generator.hpp
+++ b/tests/proptests/generators/vdf_object_generator.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <rapidcheck.h>
+#include <vdf_parser.hpp>
+
+namespace tyti::vdf
+{
+bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs);
+
+} // namespace tyti::vdf
+
+namespace rc
+{
+template <> struct Arbitrary<tyti::vdf::object>
+{
+    static Gen<tyti::vdf::object> arbitrary()
+    {
+        using tyti::vdf::object;
+        return gen::build<object>(gen::set(&object::name),
+                                  gen::set(&object::attribs));
+    }
+};
+} // namespace rc
+
+namespace rc::details
+{
+
+void showValue(tyti::vdf::object obj, std::ostream &os);
+
+void showValue(const std::tuple<tyti::vdf::object, tyti::vdf::object> &objs,
+               std::ostream &os);
+} // namespace rc::details

--- a/tests/proptests/generators/vdf_object_generator.hpp
+++ b/tests/proptests/generators/vdf_object_generator.hpp
@@ -6,6 +6,7 @@
 namespace tyti::vdf
 {
 bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs);
+bool operator==(const tyti::vdf::wobject &rhs, const tyti::vdf::wobject &lhs);
 
 } // namespace tyti::vdf
 
@@ -15,9 +16,17 @@ template <> struct Arbitrary<tyti::vdf::object>
 {
     static Gen<tyti::vdf::object> arbitrary()
     {
-        using tyti::vdf::object;
-        return gen::build<object>(gen::set(&object::name),
-                                  gen::set(&object::attribs));
+        using obj = tyti::vdf::object;
+        return gen::build<obj>(gen::set(&obj::name), gen::set(&obj::attribs));
+    }
+};
+
+template <> struct Arbitrary<tyti::vdf::wobject>
+{
+    static Gen<tyti::vdf::wobject> arbitrary()
+    {
+        using obj = tyti::vdf::wobject;
+        return gen::build<obj>(gen::set(&obj::name), gen::set(&obj::attribs));
     }
 };
 } // namespace rc

--- a/tests/proptests/generators/vdf_object_generator.hpp
+++ b/tests/proptests/generators/vdf_object_generator.hpp
@@ -29,13 +29,13 @@ template <> struct Arbitrary<tyti::vdf::wobject>
     {
         using obj = tyti::vdf::wobject;
         return gen::build<obj>(
-            gen::set(&obj::name, genValidNameString<wchar_t>()),
-            gen::set(&obj::attribs,
+            gen::set(&obj::name, gen_name_string<wchar_t>()),
+            gen::set(
+                &obj::attribs,
 
-                     rc::gen::container<
-                         std::unordered_map<std::wstring, std::wstring>>(
-                         genValidNameString<wchar_t>(),
-                         genValidNameString<wchar_t>())));
+                rc::gen::container<
+                    std::unordered_map<std::wstring, std::wstring>>(
+                    gen_name_string<wchar_t>(), gen_name_string<wchar_t>())));
     }
 };
 } // namespace rc

--- a/tests/proptests/generators/vdf_object_generator.hpp
+++ b/tests/proptests/generators/vdf_object_generator.hpp
@@ -3,6 +3,8 @@
 #include <rapidcheck.h>
 #include <vdf_parser.hpp>
 
+#include "string_generator.hpp"
+
 namespace tyti::vdf
 {
 bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs);
@@ -26,7 +28,14 @@ template <> struct Arbitrary<tyti::vdf::wobject>
     static Gen<tyti::vdf::wobject> arbitrary()
     {
         using obj = tyti::vdf::wobject;
-        return gen::build<obj>(gen::set(&obj::name), gen::set(&obj::attribs));
+        return gen::build<obj>(
+            gen::set(&obj::name, genValidNameString<wchar_t>()),
+            gen::set(&obj::attribs,
+
+                     rc::gen::container<
+                         std::unordered_map<std::wstring, std::wstring>>(
+                         genValidNameString<wchar_t>(),
+                         genValidNameString<wchar_t>())));
     }
 };
 } // namespace rc

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -2,63 +2,64 @@
 #include <vdf_parser.hpp>
 #define T_L(x) TYTI_L(charT, x)
 
+#include "generators/string_generator.hpp"
 #include "generators/vdf_multiobject_generator.hpp"
 #include "generators/vdf_object_generator.hpp"
 #include <algorithm>
 #include <string>
 
 ////////////////////////////////////////////////////////////////
-template <typename T> constexpr std::string_view getName();
+template <typename T> constexpr std::string_view name_of();
 
-template <> constexpr std::string_view getName<tyti::vdf::multikey_object>()
+template <> constexpr std::string_view name_of<tyti::vdf::multikey_object>()
 {
     return "multikey_object";
 }
-template <> constexpr std::string_view getName<tyti::vdf::wmultikey_object>()
+template <> constexpr std::string_view name_of<tyti::vdf::wmultikey_object>()
 {
     return "wmultikey_object";
 }
 
-template <> constexpr std::string_view getName<tyti::vdf::object>()
+template <> constexpr std::string_view name_of<tyti::vdf::object>()
 {
     return "object";
 }
-template <> constexpr std::string_view getName<tyti::vdf::wobject>()
+template <> constexpr std::string_view name_of<tyti::vdf::wobject>()
 {
     return "wobject";
 }
 
-template <> constexpr std::string_view getName<char>() { return "char"; }
+template <> constexpr std::string_view name_of<char>() { return "char"; }
 
-template <> constexpr std::string_view getName<wchar_t>() { return "wchar_t"; }
+template <> constexpr std::string_view name_of<wchar_t>() { return "wchar_t"; }
 ////////////////////////////////////////////////////////////////
 
 template <typename charT, template <typename T> typename basic_obj>
-bool executeTest(std::string_view test_name, auto test_f)
+bool execute_test(std::string_view test_name, auto test_f)
 {
     using obj = basic_obj<charT>;
     auto f = [test_f = std::move(test_f)]()
     { test_f.template operator()<charT, obj>(); };
 
     return rc::check(std::string{test_name} + " - " +
-                         std::string{getName<charT>()} + " - " +
-                         std::string{getName<obj>()},
+                         std::string{name_of<charT>()} + " - " +
+                         std::string{name_of<obj>()},
                      std::move(f));
 }
 
-bool forAllObjectPermutations(std::string_view test_name, auto test_f)
+bool for_all_object_permutations(std::string_view test_name, auto test_f)
 {
     using namespace tyti;
     bool ret = true;
-    ret &= executeTest<char, vdf::basic_object>(test_name, std::move(test_f));
+    ret &= execute_test<char, vdf::basic_object>(test_name, std::move(test_f));
 
-    ret &= executeTest<char, vdf::basic_multikey_object>(test_name,
-                                                         std::move(test_f));
+    ret &= execute_test<char, vdf::basic_multikey_object>(test_name,
+                                                          std::move(test_f));
     ret &=
-        executeTest<wchar_t, vdf::basic_object>(test_name, std::move(test_f));
+        execute_test<wchar_t, vdf::basic_object>(test_name, std::move(test_f));
 
-    ret &= executeTest<wchar_t, vdf::basic_multikey_object>(test_name,
-                                                            std::move(test_f));
+    ret &= execute_test<wchar_t, vdf::basic_multikey_object>(test_name,
+                                                             std::move(test_f));
     return ret;
 }
 
@@ -70,13 +71,13 @@ int main()
     using namespace tyti;
     bool success = true;
 
-    success &= forAllObjectPermutations(
+    success &= for_all_object_permutations(
         "serializing and then parsing just the name with default options "
         "should return the original name",
         []<typename charT, typename objType>()
         {
             objType obj;
-            obj.name = *genValidNameString<charT>();
+            obj.name = *gen_name_string<charT>();
 
             std::basic_stringstream<charT> sstr;
             vdf::write(sstr, obj);
@@ -85,13 +86,13 @@ int main()
             RC_ASSERT(obj.name == to_test.name);
         });
 
-    success &= forAllObjectPermutations(
+    success &= for_all_object_permutations(
         "serializing and then parsing just the name with default options "
         "should return the original name - not escaped",
         []<typename charT, typename objType>()
         {
             objType obj;
-            obj.name = *genValidUnescapedNameString<charT>();
+            obj.name = *gen_unescaped_name_string<charT>();
 
             vdf::WriteOptions writeOpts;
             writeOpts.escape_symbols = false;
@@ -106,7 +107,7 @@ int main()
             RC_ASSERT(obj.name == to_test.name);
         });
 
-    success &= forAllObjectPermutations(
+    success &= for_all_object_permutations(
         "check if the attributes are also written and parsed correctly",
         []<typename charT, typename objType>()
         {
@@ -117,7 +118,7 @@ int main()
             RC_ASSERT(in == to_test);
         });
 
-    success &= forAllObjectPermutations(
+    success &= for_all_object_permutations(
         "check if the childs are also written and parsed correctly",
         []<typename charT, typename objType>()
         {
@@ -141,7 +142,7 @@ int main()
     ////////////////////////////////////////////////////////////////
     // comments parsing tests
 
-    success &= forAllObjectPermutations(
+    success &= for_all_object_permutations(
         "single line comment should not cause any errors",
         []<typename charT, typename objType>()
         {
@@ -164,7 +165,7 @@ int main()
             RC_ASSERT(string{T_L("value")} == finder->second);
         });
 
-    success &= forAllObjectPermutations(
+    success &= for_all_object_permutations(
         "multi line comment should not cause any errors",
         []<typename charT, typename objType>()
         {

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -111,7 +111,7 @@ bool forLimitedObjectPermutation(std::string_view test_name, auto test_f)
     // todo, remove surrogate to the wobject generator and it's
     // attributes for linux support
     // afterwards, use "forAllObjectPermutations" and delete this function
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32)
     ret &=
         executeTest<wchar_t, vdf::basic_object>(test_name, std::move(test_f));
 

--- a/tests/proptests/main_rapidcheck.cpp
+++ b/tests/proptests/main_rapidcheck.cpp
@@ -1,81 +1,8 @@
+#include "generators/vdf_multiobject_generator.hpp"
+#include "generators/vdf_object_generator.hpp"
 #include <algorithm>
 #include <string>
 #include <vdf_parser.hpp>
-
-namespace rc::detail
-{
-bool operator==(const tyti::vdf::object &rhs, const tyti::vdf::object &lhs)
-{
-    if (rhs.name != lhs.name)
-        return false;
-    if (rhs.attribs != lhs.attribs)
-        return false;
-    for (const auto &[k, v] : rhs.childs)
-    {
-        auto itr = lhs.childs.find(k);
-        if (itr == lhs.childs.end())
-            return false;
-
-#ifdef _MSC_VER
-// suppress warning about recursive call of operator==. This is here
-// by intention
-#pragma warning(disable : 5232)
-#endif
-        if (itr->second != v)
-        {
-            if (itr->second == nullptr || v == nullptr || *(itr->second) != *v)
-                return false;
-        }
-#ifdef _MSC_VER
-#pragma warning(default : 5232)
-#endif
-    }
-
-    return true;
-}
-
-void showValue(tyti::vdf::object obj, std::ostream &os)
-{
-    os << "name: " << obj.name << "\n";
-    os << "attribs (size:" << obj.attribs.size() << "): \n";
-    for (const auto &[k, v] : obj.attribs)
-        os << k << "\t" << v << "\n";
-    os << "childs: (size:" << obj.childs.size() << "): \n";
-    for (const auto &[k, v] : obj.childs)
-    {
-        os << k << "\t";
-        if (v)
-            showValue(*v, os);
-        else
-            os << "nullptr!";
-        os << "\n";
-    }
-}
-void showValue(const std::tuple<tyti::vdf::object, tyti::vdf::object> &objs,
-               std::ostream &os)
-{
-    os << "[LHS]: \n";
-    showValue(std::get<0>(objs), os);
-    os << "[RHS]: \n";
-    showValue(std::get<1>(objs), os);
-}
-} // namespace rc::detail
-
-#include <rapidcheck.h>
-
-namespace rc
-{
-
-template <> struct Arbitrary<tyti::vdf::object>
-{
-    static Gen<tyti::vdf::object> arbitrary()
-    {
-        using tyti::vdf::object;
-        return gen::build<object>(gen::set(&object::name),
-                                  gen::set(&object::attribs));
-    }
-};
-} // namespace rc
 
 bool containsSurrogate(const std::wstring &str)
 {
@@ -194,12 +121,34 @@ int main()
 
             for (const auto &c : childs)
             {
-                in.childs[c->name] = c;
+                in.childs.emplace(c->name, c);
             }
 
             std::stringstream sstr;
             vdf::write(sstr, in);
             auto to_test = tyti::vdf::read(sstr);
+            RC_ASSERT(in == to_test);
+        });
+
+    success &= rc::check(
+        "check if the childs are also written and parsed correctly - multikey",
+        [](vdf::multikey_object in)
+        {
+            // todo this just tests childs with depth 1
+            using child_vec =
+                std::vector<std::shared_ptr<vdf::multikey_object>>;
+            child_vec childs = *rc::gen::container<child_vec>(
+                rc::gen::makeShared<vdf::multikey_object>(
+                    rc::gen::arbitrary<vdf::multikey_object>()));
+
+            for (const auto &c : childs)
+            {
+                in.childs.emplace(c->name, c);
+            }
+
+            std::stringstream sstr;
+            vdf::write(sstr, in);
+            auto to_test = tyti::vdf::read<vdf::multikey_object>(sstr);
             RC_ASSERT(in == to_test);
         });
 


### PR DESCRIPTION
multikey_object types were ignored in proptests so far. The coverage of wchar_t is also not that great.

This PR refactors the code, so that every test can be run against every object and char type (vdf::object, vdf::multikey_object, char, wchar_t) without rewriting/copying it.

The rapidcheck max_successes can be reduced as the coverage increases with tests being run which tests already the similar property (4x1k tests run with 10k tests before).