### PR TITLE
fixes mingw warning on windows platform

### DIFF
--- a/include/vdf_parser.hpp
+++ b/include/vdf_parser.hpp
@@ -111,14 +111,14 @@ inline std::string string_converter(const std::wstring &w) NOEXCEPT
     auto wstr = w.data();
 // unsafe: ignores any error handling
 // and disables warning that wcsrtombs_s should be used
-#ifdef WIN32
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996)
 #endif
     std::size_t len = 1 + std::wcsrtombs(nullptr, &wstr, 0, &state);
     std::string mbstr(len, '\0');
     std::wcsrtombs(&mbstr[0], &wstr, mbstr.size(), &state);
-#ifdef WIN32
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
     return mbstr;


### PR DESCRIPTION
Fixes #34


`#pragma push` and `pop` are only supported by MSVC compiler, not mingw. Therefore, those macros should check for the MSVC compiler, not the platform they are compiled for.