### PR TITLE
Fix cmake installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,14 @@ target_sources(ValveFileVDF
 #############################
 ## Install
 
-set_target_properties(ValveFileVDF PROPERTIES PUBLIC_HEADER "include/vdf_parser.hpp")
-
 include(GNUInstallDirs)
 install(TARGETS ValveFileVDF
+    EXPORT ValveFileVDFTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 include(CMakePackageConfigHelpers)
@@ -54,15 +54,20 @@ write_basic_package_version_file(
 
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-    INSTALL_DESTINATION cmake
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ValveFileVDF"
 )
 
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    DESTINATION cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ValveFileVDF"
 )
 
+install(EXPORT ValveFileVDFTargets
+    FILE ${PROJECT_NAME}Targets.cmake
+    NAMESPACE ValveFileVDF::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ValveFileVDF"
+)
 
 ###################################
 # Tests


### PR DESCRIPTION
Importing this library in cmake using `find_package(ValveFileVDF REQUIRED)` fails with the following error:

```
CMake Error at /usr/cmake/ValveFileVDFConfig.cmake:27 (include):
  include could not find requested file:

    /usr/cmake/ValveFileVDFTargets.cmake
```

This pull request fixes the issue and also fixes the installation path of the cmake files so they get installed into `lib64/cmake/ValveFileVDF` instead of `cmake`.

With these changes `find_package(ValveFileVDF)` and `target_link_libraries(<target> PRIVATE ValveFileVDF::ValveFileVDF)` work as expected for both system-wide installation and when using `CMAKE_INSTALL_PREFIX / CMAKE_PREFIX_DIR`.